### PR TITLE
Drawing external loop at the bottom by default

### DIFF
--- a/src/draw/plot.rs
+++ b/src/draw/plot.rs
@@ -115,9 +115,9 @@ fn calculate_coords(
     };
 
     let yrange = if mirror.x {
-        (upper_bounds.y + margin)..(lower_bounds.y - margin)
-    } else {
         (lower_bounds.y - margin)..(upper_bounds.y + margin)
+    } else {
+        (upper_bounds.y + margin)..(lower_bounds.y - margin)
     };
 
     Cartesian2d::<RangedCoordf64, RangedCoordf64>::new(xrange, yrange, (0..x, 0..y))

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,8 @@ fn main() -> Result<()> {
         Mirror::new(args.mx, args.my),
     )?;
 
-    println!("drawn: {:?}", &filename);
+    // rnapkin panics earlier if filename is not valid utf8
+    println!("{}", &filename.to_str().unwrap());
+
     Ok(())
 }


### PR DESCRIPTION
## changes
- BIG ONE: external loop is drawn at the bottom by default
- rnapkin now prints just the filename of the newly produced image; previously it did "drawn: {filename}"

## motivation
I am ready to admit that external loop at the top looks silly; This isn't a huge deal anyway
because it can be recreated by --mx flag. External loop at the bottom is just the better, saner
default;
